### PR TITLE
HistographicDataUpdationProblemSolved

### DIFF
--- a/src/components/CoinInfo.js
+++ b/src/components/CoinInfo.js
@@ -16,6 +16,7 @@ const CoinInfo = ({ coin }) => {
   const [historicData, setHistoricData] = useState();
   const [days, setDays] = useState(1);
   const { currency } = CryptoState();
+  const [flag,setflag] = useState(false);
 
   const useStyles = makeStyles((theme) => ({
     container: {
@@ -39,7 +40,7 @@ const CoinInfo = ({ coin }) => {
 
   const fetchHistoricData = async () => {
     const { data } = await axios.get(HistoricalChart(coin.id, days, currency));
-
+    setflag(true);
     setHistoricData(data.prices);
   };
 
@@ -62,7 +63,7 @@ const CoinInfo = ({ coin }) => {
   return (
     <ThemeProvider theme={darkTheme}>
       <div className={classes.container}>
-        {!historicData ? (
+        {!historicData | flag===false ? (
           <CircularProgress
             style={{ color: "gold" }}
             size={250}
@@ -108,7 +109,9 @@ const CoinInfo = ({ coin }) => {
               {chartDays.map((day) => (
                 <SelectButton
                   key={day.value}
-                  onClick={() => setDays(day.value)}
+                  onClick={() => {setDays(day.value);
+                    setflag(false);
+                  }}
                   selected={day.value === days}
                 >
                   {day.label}


### PR DESCRIPTION
Problem:
      while showing the graph on the CoinInfo.js page, you have used the UseState hook which eventually creates a glitch. That is when the user toggle from different timelines on the page. In that case, useEffect renders the page first and fetches the data for the graph afterward. And because of this, for some duration, it shows the graph of the previously selected timeline. And if API is somehow not able to fetch data, then in that case also it shows the graph of the previously selected timeline which is completely wrong.
 Eg:-
	Suppose a user select 24 hours timeline to view the graph, then the page will render and after that, the historicData hook get updated and shows the graph on the screen, and after some time, if the user select 365 days timeline, then in that case page will render again and this time before running useState hook function, it will show the graph of previously saved data until that fetchhistoricdata function is not executed completely.

Solution:
	I have attached a boolean flag variable whose value will become false when a user selects a timeline, and it gets true when data is completely fetched from the function fetchHistoricData and once the flag becomes true, then only data will be visible on the screen.

